### PR TITLE
feat: support GNOME Web

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ export const regexes = [
    * Some versions contains letter subversions
    */
   {
-    regex: /Maci.+ Version\/(\d+)\.(\d+)([.,](\d+)|)( \(\w+\)|)( Mobile\/\w+|) Safari\//,
+    regex: /(Maci|X11).+ Version\/(\d+)\.(\d+)([.,](\d+)|)( \(\w+\)|)( Mobile\/\w+|) Safari\//,
     family: 'safari'
   },
   /**

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ export const regexes = [
   /**
    * Safari on iPad have desktop-like useragent
    * Some versions contains letter subversions
+   * GNOME Web (X11) is based on WebKit and should be detected as Safari
    */
   {
     regex: /(Maci|X11).+ Version\/(\d+)\.(\d+)([.,](\d+)|)( \(\w+\)|)( Mobile\/\w+|) Safari\//,

--- a/test/useragents.js
+++ b/test/useragents.js
@@ -150,6 +150,13 @@ export const useragents = [
     regex: ['chrome', 'chrome@<=70']
   },
   /**
+   * GNOME Web
+   */
+  {
+    ua: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    regex: ['safari']
+  },
+  /**
    * Safari Desktop
    */
   {


### PR DESCRIPTION
[GNOME Web](https://wiki.gnome.org/Apps/Web) identifies as Safari with a WebKit version, but runs on X11, not Mac. I propose to change the syntax that's currently used for iPads to save some chars, but of course this could also be added as a separate regex.